### PR TITLE
Change storage replication to GRS

### DIFF
--- a/modules/storage_account/main.tf
+++ b/modules/storage_account/main.tf
@@ -3,7 +3,7 @@ resource "azurerm_storage_account" "this" {
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_replication_type = "GRS"
   min_tls_version          = "TLS1_2"
 
   blob_properties {


### PR DESCRIPTION
This PR changes the Azure Storage Account replication type from LRS (Locally Redundant Storage) to GRS (Geo-Redundant Storage) for enhanced data durability and disaster recovery capabilities.